### PR TITLE
Community discussion change

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ Please only use the OpenThread name and marks when accurately referencing this s
 
 # Need help?
 
-There are numerous avenues for OpenThread support:
+OpenThread support is available on GitHub:
 
-- Bugs and feature requests — [submit to the Issue Tracker](https://github.com/openthread/openthread/issues)
-- Stack Overflow — [post questions using the `openthread` tag](http://stackoverflow.com/questions/tagged/openthread)
-- Google Groups — [discussion and announcements at openthread-users](https://groups.google.com/forum/#!forum/openthread-users)
+- Bugs and feature requests pertaining to the OpenThread on CC13x2/CC26x2 Examples — [submit to the openthread/ot-cc13x2 Issue Tracker](https://github.com/openthread/ot-cc13x2/issues)
+- OpenThread bugs and feature requests — [submit to the OpenThread Issue Tracker](https://github.com/openthread/openthread/issues)
+- Community Discussion - [ask questions, share ideas, and engage with other community members](https://github.com/openthread/openthread/discussions)
 
-The openthread-users Google Group is the recommended place for users to discuss OpenThread and interact directly with the OpenThread team.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Please only use the OpenThread name and marks when accurately referencing this s
 
 OpenThread support is available on GitHub:
 
-- Bugs and feature requests pertaining to the OpenThread on CC13x2/CC26x2 Examples — [submit to the openthread/ot-cc13x2 Issue Tracker](https://github.com/openthread/ot-cc13x2/issues)
+- Bugs and feature requests pertaining to the OpenThread on CC13x2/CC26x2 Examples — [submit to the openthread/ot-cc13x2-cc26x2 Issue Tracker](https://github.com/openthread/ot-cc13x2-cc26x2/issues)
 - OpenThread bugs and feature requests — [submit to the OpenThread Issue Tracker](https://github.com/openthread/openthread/issues)
 - Community Discussion - [ask questions, share ideas, and engage with other community members](https://github.com/openthread/openthread/discussions)
-


### PR DESCRIPTION
Replace link to openthread-users Google Group with link to GitHub OpenThread Discussions, clarify issue reporting links.